### PR TITLE
Enable Work Order scoped Crown Block logs

### DIFF
--- a/app/Filament/Resources/CrownBlock/MainResource.php
+++ b/app/Filament/Resources/CrownBlock/MainResource.php
@@ -244,7 +244,7 @@ class MainResource extends Resource
     public static function getPages(): array
     {
         return [
-            'index' => MainResource\Pages\ListMains::route('/'),
+            'index' => MainResource\Pages\ListMains::route('/{wo_id?}'),
             'create' => MainResource\Pages\CreateMain::route('/create/{wo_id?}'),
             'edit' => MainResource\Pages\EditMain::route('/{record}/edit'),
             'readings' => MainResource\Pages\ManageReadings::route('/{record}/readings'),

--- a/app/Filament/Resources/CrownBlock/MainResource/Pages/ListMains.php
+++ b/app/Filament/Resources/CrownBlock/MainResource/Pages/ListMains.php
@@ -5,15 +5,38 @@ namespace App\Filament\Resources\CrownBlock\MainResource\Pages;
 use App\Filament\Resources\CrownBlock\MainResource;
 use Filament\Actions;
 use Filament\Resources\Pages\ListRecords;
+use Illuminate\Database\Eloquent\Builder;
 
 class ListMains extends ListRecords
 {
     protected static string $resource = MainResource::class;
 
+    public ?int $wo_id = null;
+
+    public function mount(): void
+    {
+        parent::mount();
+
+        $this->wo_id = (int) request()->route('wo_id');
+    }
+
     protected function getHeaderActions(): array
     {
         return [
-//            Actions\CreateAction::make(),
+            Actions\CreateAction::make()
+                ->label('New Certification')
+                ->url(fn () => MainResource::getUrl('create', ['wo_id' => $this->wo_id])),
         ];
+    }
+
+    protected function getTableQuery(): Builder
+    {
+        $query = parent::getTableQuery();
+
+        if ($this->wo_id) {
+            $query->where('wo_id', $this->wo_id);
+        }
+
+        return $query;
     }
 }

--- a/app/Filament/Resources/WorkOrderResource.php
+++ b/app/Filament/Resources/WorkOrderResource.php
@@ -53,7 +53,9 @@ class WorkOrderResource extends Resource
                     ->color(fn (WorkOrder $record) => Main::where('wo_id', $record->wo_id)->exists() ? 'success' : 'gray')
                     ->icon('heroicon-o-cube')
 //                    ->url(fn (WorkOrder $record) => CrownBlockResource::getUrl('create', ['wo_id' => $record->wo_id]))
-                    ->url(fn (WorkOrder $record) => $record->crownBlock()->exists() ? route('filament.app.resources.crown-block.mains.index') : route('filament.app.resources.crown-block.mains.create', ['wo_id' => $record->wo_id]))
+                    ->url(fn (WorkOrder $record) => $record->crownBlock()->exists()
+                        ? route('filament.app.resources.crown-block.mains.index', ['wo_id' => $record->wo_id])
+                        : route('filament.app.resources.crown-block.mains.create', ['wo_id' => $record->wo_id]))
                     ->openUrlInNewTab(),
                 Tables\Actions\ViewAction::make(),
                 Tables\Actions\EditAction::make(),

--- a/resources/views/filament/tables/columns/certification-buttons.blade.php
+++ b/resources/views/filament/tables/columns/certification-buttons.blade.php
@@ -8,7 +8,7 @@
         size="sm"
         tag="a"
         :href="$crownBlockExists
-            ? route('filament.app.resources.crown-block.mains.index')
+            ? route('filament.app.resources.crown-block.mains.index', ['wo_id' => $getRecord()->wo_id])
             : route('filament.app.resources.crown-block.mains.create', ['wo_id' => $getRecord()->wo_id])"
         target="_blank"
     >
@@ -20,7 +20,7 @@
         size="sm"
         tag="a"
         :href="$crownBlockExists
-            ? route('filament.app.resources.crown-block.mains.index')
+            ? route('filament.app.resources.crown-block.mains.index', ['wo_id' => $getRecord()->wo_id])
             : route('filament.app.resources.crown-block.mains.create', ['wo_id' => $getRecord()->wo_id])"
         target="_blank"
     >
@@ -32,7 +32,7 @@
         size="sm"
         tag="a"
         :href="$crownBlockExists
-            ? route('filament.app.resources.crown-block.mains.index')
+            ? route('filament.app.resources.crown-block.mains.index', ['wo_id' => $getRecord()->wo_id])
             : route('filament.app.resources.crown-block.mains.create', ['wo_id' => $getRecord()->wo_id])"
         target="_blank"
     >


### PR DESCRIPTION
## Summary
- filter the Crown Block log page by `wo_id`
- add a `New Certification` header action that preserves `wo_id`
- pass `wo_id` from Work Orders to the Crown Block log/create links

## Testing
- `vendor/bin/phpunit --stop-on-failure --testsuite Unit --colors=never`
- `vendor/bin/phpunit` *(fails: MissingAppKeyException)*

------
https://chatgpt.com/codex/tasks/task_e_688b0cef927c833199c681c2b53c443e